### PR TITLE
feat: add analytics spending summary endpoint

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersModule } from './modules/users/users.module';
 import { TransactionsModule } from './modules/transactions/transactions.module';
 import { WalletModule } from './modules/wallet/wallet.module';
+import { AnalyticsModule } from './modules/analytics/analytics.module';
 import { databaseConfig } from './config/database.config';
 
 @Module({
@@ -11,6 +12,7 @@ import { databaseConfig } from './config/database.config';
     UsersModule,
     TransactionsModule,
     WalletModule,
+    AnalyticsModule,
   ],
 })
 export class AppModule {}

--- a/src/modules/analytics/analytics.controller.ts
+++ b/src/modules/analytics/analytics.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { AnalyticsService } from './analytics.service';
+
+@Controller('analytics')
+export class AnalyticsController {
+  constructor(private readonly analyticsService: AnalyticsService) {}
+
+  @Get('summary')
+  async getSummary(
+    @Query('userId') userId?: string,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+  ) {
+    return this.analyticsService.getSummary({ userId, startDate, endDate });
+  }
+}

--- a/src/modules/analytics/analytics.module.ts
+++ b/src/modules/analytics/analytics.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { AnalyticsController } from './analytics.controller';
+import { AnalyticsService } from './analytics.service';
+
+@Module({
+  controllers: [AnalyticsController],
+  providers: [AnalyticsService],
+  exports: [AnalyticsService],
+})
+export class AnalyticsModule {}

--- a/src/modules/analytics/analytics.service.ts
+++ b/src/modules/analytics/analytics.service.ts
@@ -1,0 +1,92 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+
+type SummaryRow = {
+  month: string;
+  category: string;
+  total_amount: string;
+  transaction_count: string;
+};
+
+type CategorySummary = {
+  category: string;
+  totalAmount: number;
+  transactionCount: number;
+};
+
+type MonthlySummary = {
+  month: string;
+  totalAmount: number;
+  transactionCount: number;
+  categories: CategorySummary[];
+};
+
+@Injectable()
+export class AnalyticsService {
+  constructor(private readonly dataSource: DataSource) {}
+
+  async getSummary(params: {
+    userId?: string;
+    startDate?: string;
+    endDate?: string;
+  }): Promise<{
+    totalAmount: number;
+    totalTransactions: number;
+    monthly: MonthlySummary[];
+  }> {
+    const rows: SummaryRow[] = await this.dataSource.query(
+      `
+      SELECT
+        TO_CHAR(DATE_TRUNC('month', t."createdAt"), 'YYYY-MM') AS month,
+        COALESCE(NULLIF(t.category, ''), 'uncategorized') AS category,
+        SUM(t.amount)::numeric::text AS total_amount,
+        COUNT(*)::int::text AS transaction_count
+      FROM transactions t
+      WHERE ($1::uuid IS NULL OR t."userId" = $1)
+        AND ($2::date IS NULL OR t."createdAt" >= $2)
+        AND ($3::date IS NULL OR t."createdAt" < ($3::date + INTERVAL '1 day'))
+      GROUP BY DATE_TRUNC('month', t."createdAt"), category
+      ORDER BY DATE_TRUNC('month', t."createdAt") DESC, category ASC
+      `,
+      [params.userId ?? null, params.startDate ?? null, params.endDate ?? null],
+    );
+
+    const monthlyMap = new Map<string, MonthlySummary>();
+
+    for (const row of rows) {
+      const categorySummary: CategorySummary = {
+        category: row.category,
+        totalAmount: Number(row.total_amount),
+        transactionCount: Number(row.transaction_count),
+      };
+
+      const current = monthlyMap.get(row.month);
+      if (!current) {
+        monthlyMap.set(row.month, {
+          month: row.month,
+          totalAmount: categorySummary.totalAmount,
+          transactionCount: categorySummary.transactionCount,
+          categories: [categorySummary],
+        });
+        continue;
+      }
+
+      current.categories.push(categorySummary);
+      current.totalAmount += categorySummary.totalAmount;
+      current.transactionCount += categorySummary.transactionCount;
+    }
+
+    const monthly = Array.from(monthlyMap.values());
+    const totalAmount = monthly.reduce((sum, m) => sum + m.totalAmount, 0);
+    const totalTransactions = monthly.reduce(
+      (sum, m) => sum + m.transactionCount,
+      0,
+    );
+
+    return {
+      totalAmount,
+      totalTransactions,
+      monthly,
+    };
+  }
+}


### PR DESCRIPTION
## Description
Implement spending summary analytics endpoint.

## Requirements covered
- Add `GET /analytics/summary`
- Group spending by category
- Aggregate spending monthly

## Implementation details
- Added `AnalyticsController` with `GET /analytics/summary`
- Added `AnalyticsService` with a single optimized SQL aggregation query
- Query groups by month (`DATE_TRUNC('month', createdAt)`) and category
- Query computes `SUM(amount)` and `COUNT(*)` in the database
- Added optional filters: `userId`, `startDate`, `endDate`
- Added `AnalyticsModule` and wired it into `AppModule`

## API response
Returns:
- `totalAmount`
- `totalTransactions`
- `monthly[]` with month totals and per-category breakdown

## Files changed
- src/modules/analytics/analytics.controller.ts
- src/modules/analytics/analytics.service.ts
- src/modules/analytics/analytics.module.ts
- src/app.module.ts

## Acceptance criteria
- Correct summary shape returned from aggregated DB results
- Optimized DB-side aggregation query implemented

Closes #14