### PR TITLE
feat: add health check endpoint

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { RequestTimestampMiddleware } from "./common/middleware/request-timestam
 import { UsersModule } from "./modules/users/users.module";
 import { TransactionsModule } from "./modules/transactions/transactions.module";
 import { WalletModule } from "./modules/wallet/wallet.module";
+import { HealthModule } from "./health/health.module";
 import { NotificationsModule } from "./modules/notifications/notifications.module";
 import { AnalyticsModule } from "./modules/analytics/analytics.module";
 import { QueueModule } from "./queue/queue.module";
@@ -63,6 +64,7 @@ class AuthAndWalletThrottlerGuard extends ThrottlerGuard {
       }),
     }),
     
+    HealthModule,
     QueueModule,
     UsersModule,
     TransactionsModule,

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get } from "@nestjs/common";
+import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
+
+@ApiTags("health")
+@Controller("health")
+export class HealthController {
+  @Get()
+  @ApiOperation({ summary: "Health check endpoint" })
+  @ApiResponse({ status: 200, description: "API is healthy" })
+  check() {
+    return {
+      status: "ok",
+      timestamp: new Date().toISOString(),
+      version: "1.0.0",
+    };
+  }
+}

--- a/src/health/health.module.ts
+++ b/src/health/health.module.ts
@@ -1,0 +1,7 @@
+import { Module } from "@nestjs/common";
+import { HealthController } from "./health.controller";
+
+@Module({
+  controllers: [HealthController],
+})
+export class HealthModule {}


### PR DESCRIPTION
## Summary
Add a `/health` endpoint for monitoring API availability, as requested in #64.

## Changes
- Created `src/health/health.module.ts` — NestJS module
- Created `src/health/health.controller.ts` — controller with Swagger docs
- Registered `HealthModule` in `AppModule`

## Endpoint Response
```json
{
  "status": "ok",
  "timestamp": "2026-06-14T10:30:00.000Z",
  "version": "1.0.0"
}
```

## Acceptance Criteria
- [x] `/health` endpoint responds successfully
- [x] JSON response includes status and timestamp
- [x] Swagger documentation added via `@ApiTags` and `@ApiOperation`
- [x] Follows existing module conventions (mirrors UsersModule, WalletModule pattern)

Closes #64