### PR TITLE
Add request middleware tests

### DIFF
--- a/src/common/middleware/logger.middleware.spec.ts
+++ b/src/common/middleware/logger.middleware.spec.ts
@@ -1,0 +1,58 @@
+import { Logger } from '@nestjs/common';
+import { EventEmitter } from 'events';
+import { Request, Response } from 'express';
+
+import { LoggerMiddleware } from './logger.middleware';
+
+describe('LoggerMiddleware', () => {
+  let logSpy: jest.SpyInstance;
+  let dateNowSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    dateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_047);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('logs method, original URL, status code, and duration when the response finishes', () => {
+    const middleware = new LoggerMiddleware();
+    const req = {
+      method: 'POST',
+      originalUrl: '/api/transactions?limit=10',
+    } as Request;
+    const res = Object.assign(new EventEmitter(), {
+      statusCode: 201,
+    }) as Response & EventEmitter;
+    const next = jest.fn();
+
+    middleware.use(req, res, next);
+    res.emit('finish');
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(dateNowSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy).toHaveBeenCalledWith(
+      'POST /api/transactions?limit=10 201 - 47ms',
+    );
+  });
+
+  it('does not log before the response emits finish', () => {
+    const middleware = new LoggerMiddleware();
+    const req = {
+      method: 'GET',
+      originalUrl: '/api/wallet',
+    } as Request;
+    const res = Object.assign(new EventEmitter(), {
+      statusCode: 200,
+    }) as Response & EventEmitter;
+
+    middleware.use(req, res, jest.fn());
+
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/common/middleware/request-timestamp.middleware.spec.ts
+++ b/src/common/middleware/request-timestamp.middleware.spec.ts
@@ -1,0 +1,54 @@
+import { Logger } from '@nestjs/common';
+import { Response } from 'express';
+
+import { RequestTimestampMiddleware } from './request-timestamp.middleware';
+
+interface RequestWithTimestamp {
+  method: string;
+  url: string;
+  requestTimestamp?: string;
+}
+
+describe('RequestTimestampMiddleware', () => {
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest
+      .useFakeTimers()
+      .setSystemTime(new Date('2026-06-20T08:15:30.123Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('attaches an ISO timestamp to the request before continuing', () => {
+    const middleware = new RequestTimestampMiddleware();
+    const req: RequestWithTimestamp = {
+      method: 'PATCH',
+      url: '/api/budgets/weekly',
+    };
+    const next = jest.fn();
+
+    middleware.use(req as never, {} as Response, next);
+
+    expect(req.requestTimestamp).toBe('2026-06-20T08:15:30.123Z');
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs the timestamped request method and URL', () => {
+    const middleware = new RequestTimestampMiddleware();
+    const req: RequestWithTimestamp = {
+      method: 'DELETE',
+      url: '/api/transactions/txn_123',
+    };
+
+    middleware.use(req as never, {} as Response, jest.fn());
+
+    expect(logSpy).toHaveBeenCalledWith(
+      '[2026-06-20T08:15:30.123Z] DELETE /api/transactions/txn_123',
+    );
+  });
+});


### PR DESCRIPTION
Closes #80.

## Summary
- Add focused coverage for LoggerMiddleware finish-event logging.
- Add focused coverage for RequestTimestampMiddleware timestamp attachment and request log output.

## Validation
- 
pm test -- src/common/middleware --runInBand passed: 2 suites / 4 tests.
- 
px eslint src/common/middleware/logger.middleware.ts src/common/middleware/logger.middleware.spec.ts src/common/middleware/request-timestamp.middleware.ts src/common/middleware/request-timestamp.middleware.spec.ts passed.
- 
px tsc --noEmit --pretty false passed.

Note: local 
pm install initially hit the known Windows native sqlite3 build path because this host lacks the VC++ toolset, so I installed dependencies with --ignore-scripts for JS-only test validation. No application code or lockfile changes are included.