### PR TITLE
rate -limiting

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,15 +22,21 @@ import { APP_GUARD } from "@nestjs/core";
 import { ThrottlerGuard, ThrottlerModule } from "@nestjs/throttler";
 import { CacheModule } from "@nestjs/cache-manager";
 import { redisStore } from "cache-manager-redis-store";
+import {
+  AUTH_THROTTLE_LIMIT,
+  AUTH_THROTTLE_TTL,
+} from "./common/constants/throttle.constants";
+
+const RATE_LIMITED_ROUTE_PREFIXES = ["/auth", "/wallet", "/notifications"] as const;
 
 @Injectable()
-class AuthAndWalletThrottlerGuard extends ThrottlerGuard {
+class ProtectedRoutesThrottlerGuard extends ThrottlerGuard {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const req = context
       .switchToHttp()
       .getRequest<import("express").Request & { path?: string }>();
     const path: string = req.path ?? req.url ?? "";
-    if (path.startsWith("/wallet") || path.startsWith("/auth")) {
+    if (RATE_LIMITED_ROUTE_PREFIXES.some((prefix) => path.startsWith(prefix))) {
       return super.canActivate(context);
     }
     return true;
@@ -44,8 +50,8 @@ class AuthAndWalletThrottlerGuard extends ThrottlerGuard {
     ThrottlerModule.forRoot({
       throttlers: [
         {
-          ttl: 60_000,
-          limit: 10,
+          ttl: AUTH_THROTTLE_TTL,
+          limit: AUTH_THROTTLE_LIMIT,
         },
       ],
       setHeaders: true,
@@ -75,7 +81,7 @@ class AuthAndWalletThrottlerGuard extends ThrottlerGuard {
     AppService,
     {
       provide: APP_GUARD,
-      useClass: AuthAndWalletThrottlerGuard,
+      useClass: ProtectedRoutesThrottlerGuard,
     },
   ],
 })

--- a/src/common/constants/throttle.constants.ts
+++ b/src/common/constants/throttle.constants.ts
@@ -1,0 +1,16 @@
+export const AUTH_THROTTLE_TTL = 60_000;
+export const AUTH_THROTTLE_LIMIT = 10;
+export const AUTH_LOGIN_THROTTLE_LIMIT = 5;
+export const NOTIFICATIONS_THROTTLE_LIMIT = 5;
+
+export const AUTH_THROTTLE = {
+  default: { limit: AUTH_THROTTLE_LIMIT, ttl: AUTH_THROTTLE_TTL },
+} as const;
+
+export const AUTH_LOGIN_THROTTLE = {
+  default: { limit: AUTH_LOGIN_THROTTLE_LIMIT, ttl: AUTH_THROTTLE_TTL },
+} as const;
+
+export const NOTIFICATIONS_THROTTLE = {
+  default: { limit: NOTIFICATIONS_THROTTLE_LIMIT, ttl: AUTH_THROTTLE_TTL },
+} as const;

--- a/src/modules/auth/auth.controller.spec.ts
+++ b/src/modules/auth/auth.controller.spec.ts
@@ -1,0 +1,75 @@
+import { INestApplication, UnauthorizedException } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
+import request from 'supertest';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+
+describe('AuthController rate limiting', () => {
+  let app: INestApplication;
+
+  const loginPayload = {
+    publicKey: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+    signature: 'invalid-signature',
+    message: 'login-message',
+  };
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        ThrottlerModule.forRoot({
+          throttlers: [{ ttl: 60_000, limit: 5 }],
+          setHeaders: true,
+        }),
+      ],
+      controllers: [AuthController],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: {
+            login: jest.fn().mockRejectedValue(new UnauthorizedException('Invalid signature')),
+            getStatus: jest.fn().mockReturnValue({ module: 'Auth', status: 'Working' }),
+          },
+        },
+        {
+          provide: APP_GUARD,
+          useClass: ThrottlerGuard,
+        },
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns 429 after exceeding the login rate limit', async () => {
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      await request(app.getHttpServer()).post('/auth/login').send(loginPayload);
+    }
+
+    const response = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send(loginPayload);
+
+    expect(response.status).toBe(429);
+    expect(response.body).toMatchObject({
+      statusCode: 429,
+      message: 'ThrottlerException: Too Many Requests',
+    });
+  });
+
+  it('includes rate limit headers on login responses', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send(loginPayload);
+
+    expect(response.headers['x-ratelimit-limit']).toBe('5');
+    expect(response.headers['x-ratelimit-remaining']).toBeDefined();
+    expect(response.headers['x-ratelimit-reset']).toBeDefined();
+  });
+});

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,19 +1,27 @@
 import { Controller, Get, Post, Body } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBody } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
+import {
+  AUTH_LOGIN_THROTTLE,
+  AUTH_THROTTLE,
+} from '../../common/constants/throttle.constants';
 
 @ApiTags('auth')
 @Controller('auth')
+@Throttle(AUTH_THROTTLE)
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('login')
+  @Throttle(AUTH_LOGIN_THROTTLE)
   @ApiOperation({ summary: 'Login with Stellar wallet signature' })
   @ApiBody({ type: LoginDto })
   @ApiResponse({ status: 201, description: 'Login successful, returns access token' })
   @ApiResponse({ status: 401, description: 'Invalid signature or wallet not found' })
   @ApiResponse({ status: 400, description: 'Invalid request body' })
+  @ApiResponse({ status: 429, description: 'Too many login attempts' })
   async login(@Body() loginDto: LoginDto) {
     return this.authService.login(loginDto);
   }

--- a/src/modules/notifications/notifications.controller.spec.ts
+++ b/src/modules/notifications/notifications.controller.spec.ts
@@ -1,0 +1,77 @@
+import { INestApplication } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
+import request from 'supertest';
+import { NotificationsController } from './notifications.controller';
+import { NotificationsService } from './notifications.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AccountStatusGuard } from '../../common/guards/account-status.guard';
+
+describe('NotificationsController rate limiting', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        ThrottlerModule.forRoot({
+          throttlers: [{ ttl: 60_000, limit: 10 }],
+          setHeaders: true,
+        }),
+      ],
+      controllers: [NotificationsController],
+      providers: [
+        {
+          provide: NotificationsService,
+          useValue: {
+            getStatus: jest.fn().mockReturnValue({ module: 'Notifications', status: 'Working' }),
+            findByUserId: jest.fn(),
+            findUnreadByUserId: jest.fn(),
+            create: jest.fn(),
+            markAsRead: jest.fn(),
+            markAllAsRead: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+        {
+          provide: APP_GUARD,
+          useClass: ThrottlerGuard,
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(AccountStatusGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns 429 after exceeding the notifications rate limit', async () => {
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      await request(app.getHttpServer()).get('/notifications/status');
+    }
+
+    const response = await request(app.getHttpServer()).get('/notifications/status');
+
+    expect(response.status).toBe(429);
+    expect(response.body).toMatchObject({
+      statusCode: 429,
+      message: 'ThrottlerException: Too Many Requests',
+    });
+  });
+
+  it('includes rate limit headers on notification responses', async () => {
+    const response = await request(app.getHttpServer()).get('/notifications/status');
+
+    expect(response.headers['x-ratelimit-limit']).toBe('5');
+    expect(response.headers['x-ratelimit-remaining']).toBeDefined();
+    expect(response.headers['x-ratelimit-reset']).toBeDefined();
+  });
+});

--- a/src/modules/notifications/notifications.controller.ts
+++ b/src/modules/notifications/notifications.controller.ts
@@ -17,9 +17,11 @@ import {
   ApiParam,
   ApiBearerAuth,
 } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 import { NotificationsService, CreateNotificationDto } from './notifications.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AccountStatusGuard } from '../../common/guards/account-status.guard';
+import { NOTIFICATIONS_THROTTLE } from '../../common/constants/throttle.constants';
 
 interface AuthenticatedRequest {
   user?: {
@@ -31,6 +33,7 @@ interface AuthenticatedRequest {
 @ApiBearerAuth()
 @Controller('notifications')
 @UseGuards(JwtAuthGuard, AccountStatusGuard)
+@Throttle(NOTIFICATIONS_THROTTLE)
 export class NotificationsController {
   constructor(private readonly notificationsService: NotificationsService) {}
 


### PR DESCRIPTION
Configuration (src/app.module.ts)
@nestjs/throttler is configured with a default limit of 10 requests/minute and setHeaders: true (adds X-RateLimit-* headers).
The guard was renamed to ProtectedRoutesThrottlerGuard and now covers /auth, /wallet, and /notifications.
Auth endpoints (src/modules/auth/auth.controller.ts)
Class-level @Throttle: 10 req/min for general auth routes.
Login endpoint: stricter 5 req/min (brute-force protection).
Swagger documents the 429 response.
Notification endpoints (src/modules/notifications/notifications.controller.ts)
Class-level @Throttle: 5 req/min (stricter than general auth).
Shared constants (src/common/constants/throttle.constants.ts)
Centralizes throttle limits for reuse in controllers and tests.
Tests
src/modules/auth/auth.controller.spec.ts — verifies login returns 429 after 5 attempts and rate-limit headers are present.
src/modules/notifications/notifications.controller.spec.ts — same checks for notification routes.
All 326 tests pass and the build succeeds.

Note: Full npm run ci still fails on a pre-existing lint error in src/modules/transactions/dto/query-transactions.dto.ts (unused IsPositive import). That file wasn’t part of this change. I can remove that import so CI passes if you want.


close #70 